### PR TITLE
define a separate owner in RetirementFund.t.sol

### DIFF
--- a/RetirementFund/test/RetirementFund.t.sol
+++ b/RetirementFund/test/RetirementFund.t.sol
@@ -8,8 +8,14 @@ contract RetirementFundTest is Test {
     RetirementFund public retirementFund;
     ExploitContract public exploitContract;
 
+    // owner that will deploy the contract. Do not use it as a prank.
+    address owner = makeAddr("owner");
+
     function setUp() public {
         // Deploy contracts
+        vm.deal(owner, 1 ether);
+        // use owner to deploy the contract
+        vm.prank(owner);
         retirementFund = (new RetirementFund){value: 1 ether}(address(this));
         exploitContract = new ExploitContract(retirementFund);
     }


### PR DESCRIPTION
`msg.sender` is both owner as well as beneficiary. For this CTF to be challenging, owner should be different than beneficiary.

I propose `RetirementFundTest` as beneficiary and address generated by `makeAddr("owner")` as the owner of `RetirementFund`.